### PR TITLE
Refactor: Always output digest summary log by default

### DIFF
--- a/dirdigest/utils/logger.py
+++ b/dirdigest/utils/logger.py
@@ -58,7 +58,7 @@ def setup_logging(
     elif verbose_level >= 1:  # -v
         console_log_level_name = "INFO"
     else:  # Default operation (no -v, no -q)
-        console_log_level_name = "WARNING"  # Default console logs warnings and above
+        console_log_level_name = "INFO"  # Default console logs info and above
 
     # Remove any existing handlers to prevent duplicate logs if setup_logging is called multiple times
     for handler in logger.handlers[:]:


### PR DESCRIPTION
The digest summary log, which includes information like total files included, excluded, total content size, and execution time, is now printed to the console by default (INFO level).

Previously, the summary was only displayed if the -v (verbose) flag was used, as the default console logging level was WARNING. This change modifies the default console logging level in `utils/logger.py` to INFO.

The behavior of the -q (quiet) flag (suppresses INFO and WARNING) and the -v flag (enables INFO) and -vv (enables DEBUG) remains unchanged, ensuring you can still control verbosity as needed.